### PR TITLE
Feature/automatic scaling

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -4,5 +4,5 @@ instance_class: F4
 automatic_scaling:
   max_instances: 10
   max_concurrent_requests: 4
-  target_throughput_utilization: 0.55
+  target_throughput_utilization: 0.7
 # [END app_yaml]

--- a/app.yaml
+++ b/app.yaml
@@ -4,5 +4,5 @@ instance_class: F4
 automatic_scaling:
   max_instances: 10
   max_concurrent_requests: 4
-  target_throughput_utilization: 0.5
+  target_throughput_utilization: 0.55
 # [END app_yaml]

--- a/app.yaml
+++ b/app.yaml
@@ -3,6 +3,6 @@ runtime: nodejs8
 instance_class: F4
 automatic_scaling:
   max_instances: 10
-  max_concurrent_requests: 4
+  max_concurrent_requests: 5
   target_throughput_utilization: 0.7
 # [END app_yaml]

--- a/app.yaml
+++ b/app.yaml
@@ -1,7 +1,8 @@
 # [START app_yaml]
 runtime: nodejs8
-instance_class: B4
-basic_scaling:
+instance_class: F4
+automatic_scaling:
   max_instances: 10
-  idle_timeout: 1m
+  max_concurrent_requests: 4
+  target_throughput_utilization: 0.5
 # [END app_yaml]


### PR DESCRIPTION
GAE のスケーリング設定を変更
### 経緯
1. Basic Scaling ではスケールアウトのパラメーター調整ができないため Automatic Scaling に変更
1. メモリ利用量によってスケールアウトするのが望ましいが、パラメーターで調整できなかったため、1インスタンスあたりの同時リクエスト数で設定
1. リソースの利用状況からF4インスタンスで同時2リクエスト（録音）が処理できるため `max_concurrent_requests` × `target_throughput_utilization` が 2〜3 になるように設定するのが望ましいと考えたが、`max_concurrent_requests` × `target_throughput_utilization` が 3.5 になるように設定しても、1リクエストあたり1インスタンスが立ち上がるので、暫定的にこの設定を適用
### 参考
- https://cloud.google.com/appengine/docs/standard/nodejs/how-instances-are-managed
- https://cloud.google.com/appengine/docs/standard/nodejs/config/appref